### PR TITLE
Add MPD as a transfer format to FireTV config

### DIFF
--- a/config/devices/amazon-firetv-default.json
+++ b/config/devices/amazon-firetv-default.json
@@ -29,8 +29,8 @@
             "h264"
           ],
           "transferFormat": [
-            "hls",
-            "plain"
+            "mpd",
+            "hls"
           ],
           "maximumBitRate": 3600,
           "maximumVideoLines": 1080


### PR DESCRIPTION
Trello: https://trello.com/c/IeOYop8j
- Updates the config for Amazon Fire TV to include "mpd" as it's priority transfer format of choice
- Keeps HLS as a second choice
